### PR TITLE
css for code and video

### DIFF
--- a/src/scss/common/_netbeans.scss
+++ b/src/scss/common/_netbeans.scss
@@ -97,6 +97,11 @@ code {
   border: 0;
 }
 
+code:not(.hljs) {
+  background-color: $nb-pre-background;
+  border: 1px solid #EEE;
+}
+
 pre {
   background-color: $nb-pre-background;
   border: 1px solid #CCC;

--- a/src/scss/components/_video.scss
+++ b/src/scss/components/_video.scss
@@ -44,5 +44,6 @@
         width: 968px;
         height:auto; 
         max-height:490px;
+        cursor: pointer;
     }
 }

--- a/src/scss/components/_video.scss
+++ b/src/scss/components/_video.scss
@@ -39,3 +39,10 @@
     }
 }
 
+.videoconsentblock {
+    .content img {
+        width: 968px;
+        height:auto; 
+        max-height:490px;
+    }
+}


### PR DESCRIPTION
This PR make the previous image for video width up to the same size at the video to avoid layout break.

Trying also to improve "inline" code to have a bit more contrast. See WheelPanAction
![image](https://github.com/apache/netbeans-antora-ui/assets/6940099/7ba13a97-1144-49b2-bd7c-56246e57d08d)
